### PR TITLE
Add support for strip-components

### DIFF
--- a/e2e.sh
+++ b/e2e.sh
@@ -31,7 +31,7 @@ echo running fastar command
 ./fastar http://localhost:8000/image.tar.lz4 -C ~/fastar
 
 echo checking if results differ
-if diff --no-dereference -bur ~/tar ~/fastar; then
+if diff -bur ~/tar ~/fastar; then
   echo directories match
 else
   echo directories do not match

--- a/fastar.go
+++ b/fastar.go
@@ -18,11 +18,12 @@ import (
 )
 
 var (
-	rawUrl       = kingpin.Arg("url", "URL to download from").Required().String()
-	numWorkers   = kingpin.Flag("download-workers", "How many parallel workers to download the file").Default("16").Int()
-	chunkSize    = kingpin.Flag("chunk-size", "Size of file chunks (in MB) to pull in parallel").Default("50").Uint64()
-	outputDir    = kingpin.Flag("directory", "Directory to extract tarball to. Dumps file to stdout if not specified.").Short('C').ExistingDir()
-	writeWorkers = kingpin.Flag("write-workers", "How many parallel workers to use to write file to disk").Default("8").Int()
+	rawUrl          = kingpin.Arg("url", "URL to download from").Required().String()
+	numWorkers      = kingpin.Flag("download-workers", "How many parallel workers to download the file").Default("16").Int()
+	chunkSize       = kingpin.Flag("chunk-size", "Size of file chunks (in MB) to pull in parallel").Default("50").Uint64()
+	outputDir       = kingpin.Flag("directory", "Directory to extract tarball to. Dumps file to stdout if not specified.").Short('C').ExistingDir()
+	writeWorkers    = kingpin.Flag("write-workers", "How many parallel workers to use to write file to disk").Default("8").Int()
+	stripComponents = kingpin.Flag("strip-components", "Strip STRIP-COMPONENTS leading components from file names on extraction").Int()
 )
 
 func main() {


### PR DESCRIPTION
Add flag for number of leading directories to strip

Also fix unit test to not check for equality of symlinks based on the pointer but what it points to.
In the linux tarball there's a symlink that contains a "/./" which we take out (technically the same but
diff says they're different when using --no-dereference)