### PR TITLE
Add support for --overwrite

### DIFF
--- a/fastar.go
+++ b/fastar.go
@@ -28,6 +28,7 @@ var (
 	retryCount      = kingpin.Flag("retry-count", "Max number of retries for a single chunk").Default("10").Int()
 	retryWait       = kingpin.Flag("retry-wait", "Max number of seconds to wait in between retries (with jitter)").Default("8").Int()
 	ignoreNodeFiles = kingpin.Flag("ignore-node-files", "Don't throw errors on character or block device nodes").Default("false").Bool()
+	overwrite       = kingpin.Flag("overwrite", "Overwrite any existing files").Default("false").Bool()
 )
 
 const (

--- a/fileserver/fileserver.go
+++ b/fileserver/fileserver.go
@@ -10,5 +10,6 @@ import (
 func main() {
 	fs := http.FileServer(http.Dir("/tmp"))
 	limiter := tollbooth.LimitHandler(tollbooth.NewLimiter(5, nil), fs)
+	log.Fatal(http.ListenAndServe(":8000", fs))
 	log.Fatal(http.ListenAndServe(":8000", limiter))
 }


### PR DESCRIPTION
Delete existing files if overwrite flag set.

Change hard link logic to wait on a token for normal file creation if the file hasn't been made yet. (rather than making a dummy file)
This avoids nasty races when both deleting the hard link target due to overwrite while also making dummy files in the hard link logic.