### PR TITLE
Add flag to skip existing files

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -225,4 +225,5 @@ func writePartial(
 		}
 		reader.AdvanceNextChunk()
 	}
+	fmt.Fprintf(os.Stderr, "Worker %d total download speed %.3fMBps\n", workerNum, totalDownloaded/1e3/timeDownloadingMilli)
 }

--- a/fastar.go
+++ b/fastar.go
@@ -32,6 +32,7 @@ var opts struct {
 	ConnTimeout     int               `long:"connection-timeout" default:"60" description:"Abort download if TCP dial takes longer than this many seconds"`
 	IgnoreNodeFiles bool              `long:"ignore-node-files" description:"Don't throw errors on character or block device nodes"`
 	Overwrite       bool              `long:"overwrite" description:"Overwrite any existing files"`
+	SkipOldFiles    bool              `long:"skip-old-files" description:"Silently skip existing files when extracting"`
 	Headers         map[string]string `long:"headers" short:"H" description:"Headers to use with http request"`
 }
 

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -26,6 +26,7 @@ type HttpDownloader struct {
 func (httpDownloader HttpDownloader) GetFileInfo() (int64, bool, bool) {
 	req := httpDownloader.generateRequest()
 	resp := httpDownloader.retryHttpRequest(req)
+	resp.Body.Close()
 
 	if resp.ContentLength > opts.ChunkSize {
 		_, err := httpDownloader.GetRanges([][]int64{{0, 1}, {1, 2}})

--- a/tar.go
+++ b/tar.go
@@ -56,6 +56,12 @@ func ExtractTar(stream io.Reader) {
 			continue
 		}
 		path := filepath.Join(opts.OutputDir, name)
+		if opts.SkipOldFiles {
+			if _, err = os.Stat(path); err == nil {
+				// User passed the --skip-old-files flag and this file already exists so skip extraction
+				continue
+			}
+		}
 		info := header.FileInfo()
 		pathDir, _ := filepath.Split(path)
 		if _, err = os.Stat(pathDir); os.IsNotExist(err) {


### PR DESCRIPTION
Also add a missing resp.Body.Close() and a helpful log line for overall worker DL speed.