### PR TITLE
[CJ-58913] GCP CMv1 - Add support for GCP IAM access token in fastar

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"golang.org/x/oauth2"
 	"golang.org/x/sys/unix"
 	"google.golang.org/api/option"
 )
@@ -90,8 +91,15 @@ func GetDownloader(url string, useFips bool) Downloader {
 
 		// Add custom credentials option if defined
 		credsJSON := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+		gcsAccessToken := os.Getenv("GCS_ACCESS_TOKEN")
 		if credsJSON != "" {
 			options = append(options, option.WithCredentialsJSON([]byte(credsJSON)))
+		} else if gcsAccessToken != "" {
+			// Create a token source that always returns the static access token
+			tokenSource := oauth2.StaticTokenSource(
+				&oauth2.Token{AccessToken: gcsAccessToken},
+			)
+			options = append(options, option.WithTokenSource(tokenSource))
 		}
 
 		client, err := storage.NewClient(


### PR DESCRIPTION
See title.

Tested by ensuring fastar can download file from GCS bucket using `--gcs-access-token` flag.

```
GCS_ACCESS_TOKEN=ya29.a0AXo***REDACTED***8Q0178 ./fastar gs://databricks-dev-artifacts-us-east4/image.tar.lz4 --directory ./outstuff
2024/06/24 12:55:12 File Size (MiB): 0
2024/06/24 12:55:12 Supports RANGE: true
2024/06/24 12:55:12 Supports multipart RANGE: false
2024/06/24 12:55:12 File name: image.tar.lz4
2024/06/24 12:55:12 Num Download Workers: 4
2024/06/24 12:55:12 Chunk Size (Mib): 200
2024/06/24 12:55:12 Num Disk Workers: 8
2024/06/24 12:55:12 Inferring lz4 by magic number
```