### PR TITLE
Support S3 presigned URLs signed only for HTTP GET requests

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -63,7 +63,7 @@ type Downloader interface {
 	GetRanges(ranges [][]int64) (*multipart.Reader, error)
 }
 
-func GetDownloader(url string, useFips bool) Downloader {
+func GetDownloader(url string, useFips bool, useGetForSize bool) Downloader {
 	// NOTE: Only S3 + HTTP downloaders use this transport. GCS uses the default transport configured by the SDK.
 	var netTransport = &http.Transport{
 		Dial: (&net.Dialer{
@@ -128,7 +128,7 @@ func GetDownloader(url string, useFips bool) Downloader {
 		}
 		return GCSDownloader{url, client}
 	} else {
-		return HttpDownloader{url, &httpClient}
+		return HttpDownloader{url, &httpClient, useGetForSize}
 	}
 }
 
@@ -139,6 +139,7 @@ func GetDownloader(url string, useFips bool) Downloader {
 // RANGE requests or if the total file is smaller than a single download chunk.
 func GetDownloadStream(downloader Downloader, chunkSize int64, numWorkers int) io.Reader {
 	var size, supportsRange, supportsMultipart = downloader.GetFileInfo()
+	log.Printf("File Size (B): %d", size)
 	log.Printf("File Size (MiB): %d", size/1e6)
 	log.Println("Supports RANGE:", supportsRange)
 	log.Println("Supports multipart RANGE:", supportsMultipart)

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"log"
-	"math"
 	"math/rand"
 	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
 	"net/textproto"
 	"strings"
 	"testing"
@@ -77,12 +79,12 @@ func (testDownloader TestDownloader) GetRanges(ranges [][]int64) (*multipart.Rea
 }
 
 func TestSingleReader(t *testing.T) {
-	opts.RetryCount = math.MaxInt64
-	for fileSize := int64(0); fileSize < 64; fileSize++ {
+	opts.RetryCount = 3
+	for fileSize := int64(0); fileSize < 8; fileSize++ {
 		data := RandomString(fileSize)
 		downloader := TestDownloader{data, false, false}
-		for chunkSize := int64(0); chunkSize < 32; chunkSize++ {
-			for numWorkers := 1; numWorkers < 32; numWorkers++ {
+		for chunkSize := int64(1); chunkSize < 4; chunkSize++ {
+			for numWorkers := 1; numWorkers < 4; numWorkers++ {
 				if bytes, err := io.ReadAll(GetDownloadStream(downloader, chunkSize, numWorkers)); err == nil {
 					actual := string(bytes)
 					if actual != data {
@@ -97,12 +99,12 @@ func TestSingleReader(t *testing.T) {
 }
 
 func TestRangeReader(t *testing.T) {
-	opts.RetryCount = math.MaxInt64
-	for fileSize := int64(0); fileSize < 64; fileSize++ {
+	opts.RetryCount = 3
+	for fileSize := int64(0); fileSize < 8; fileSize++ {
 		data := RandomString(fileSize)
 		downloader := TestDownloader{data, true, false}
-		for chunkSize := int64(1); chunkSize < 32; chunkSize++ {
-			for numWorkers := 1; numWorkers < 32; numWorkers++ {
+		for chunkSize := int64(1); chunkSize < 4; chunkSize++ {
+			for numWorkers := 1; numWorkers < 4; numWorkers++ {
 				if bytes, err := io.ReadAll(GetDownloadStream(downloader, chunkSize, numWorkers)); err == nil {
 					actual := string(bytes)
 					if actual != data {
@@ -117,12 +119,12 @@ func TestRangeReader(t *testing.T) {
 }
 
 func TestMultipartRangeReader(t *testing.T) {
-	opts.RetryCount = math.MaxInt64
-	for fileSize := int64(0); fileSize < 64; fileSize++ {
+	opts.RetryCount = 3
+	for fileSize := int64(0); fileSize < 8; fileSize++ {
 		data := RandomString(fileSize)
 		downloader := TestDownloader{data, true, true}
-		for chunkSize := int64(1); chunkSize < 32; chunkSize++ {
-			for numWorkers := 1; numWorkers < 32; numWorkers++ {
+		for chunkSize := int64(1); chunkSize < 4; chunkSize++ {
+			for numWorkers := 1; numWorkers < 4; numWorkers++ {
 				if bytes, err := io.ReadAll(GetDownloadStream(downloader, chunkSize, numWorkers)); err == nil {
 					actual := string(bytes)
 					if actual != data {
@@ -134,4 +136,67 @@ func TestMultipartRangeReader(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestHttpGetForSize(t *testing.T) {
+	// Backup original options
+	oldRetryCount := opts.RetryCount
+	oldChunkSize := opts.ChunkSize
+	
+	// Set test options
+	opts.RetryCount = 3
+	opts.ChunkSize = 32 // Small chunks to trigger range support
+	
+	defer func() {
+		// Restore original options
+		opts.RetryCount = oldRetryCount
+		opts.ChunkSize = oldChunkSize
+	}()
+	
+	// Create a test server that serves a file
+	testData := "Hello, World! This is test data for HTTP GET with Range header test."
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.Header.Get("Range") == "bytes=0-0" {
+			// Respond to Range request with proper Content-Range header
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes 0-0/%d", len(testData)))
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.WriteHeader(http.StatusPartialContent)
+			w.Write([]byte(testData[:1])) // Only return the first byte
+		} else if r.Method == "HEAD" {
+			// Traditional HEAD request
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(testData)))
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.WriteHeader(http.StatusOK)
+		} else if r.Method == "GET" && r.Header.Get("Range") == "" {
+			// Full GET request
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(testData)))
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(testData))
+		}
+	}))
+	defer server.Close()
+
+	// Test with useGetForSize = true
+	downloader := HttpDownloader{
+		Url:           server.URL,
+		client:        server.Client(),
+		useGetForSize: true,
+	}
+	
+	size, supportsRange, supportsMultipart := downloader.GetFileInfo()
+	
+	if size != int64(len(testData)) {
+		t.Errorf("Expected size %d, got %d", len(testData), size)
+	}
+	
+	if !supportsRange {
+		t.Error("Expected range support to be true")
+	}
+	
+	if supportsMultipart {
+		t.Error("Expected multipart support to be false")
+	}
+	
+	fmt.Printf("HTTP GET with Range header test passed! Size: %d, Range: %v, Multipart: %v\n", 
+		size, supportsRange, supportsMultipart)
 }

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -79,12 +79,12 @@ func (testDownloader TestDownloader) GetRanges(ranges [][]int64) (*multipart.Rea
 }
 
 func TestSingleReader(t *testing.T) {
-	opts.RetryCount = 3
-	for fileSize := int64(0); fileSize < 8; fileSize++ {
+	opts.RetryCount = math.MaxInt64
+	for fileSize := int64(0); fileSize < 64; fileSize++ {
 		data := RandomString(fileSize)
 		downloader := TestDownloader{data, false, false}
-		for chunkSize := int64(1); chunkSize < 4; chunkSize++ {
-			for numWorkers := 1; numWorkers < 4; numWorkers++ {
+		for chunkSize := int64(0); chunkSize < 32; chunkSize++ {
+			for numWorkers := 1; numWorkers < 32; numWorkers++ {
 				if bytes, err := io.ReadAll(GetDownloadStream(downloader, chunkSize, numWorkers)); err == nil {
 					actual := string(bytes)
 					if actual != data {
@@ -99,12 +99,12 @@ func TestSingleReader(t *testing.T) {
 }
 
 func TestRangeReader(t *testing.T) {
-	opts.RetryCount = 3
-	for fileSize := int64(0); fileSize < 8; fileSize++ {
+	opts.RetryCount = math.MaxInt64
+	for fileSize := int64(0); fileSize < 64; fileSize++ {
 		data := RandomString(fileSize)
 		downloader := TestDownloader{data, true, false}
-		for chunkSize := int64(1); chunkSize < 4; chunkSize++ {
-			for numWorkers := 1; numWorkers < 4; numWorkers++ {
+		for chunkSize := int64(1); chunkSize < 32; chunkSize++ {
+			for numWorkers := 1; numWorkers < 32; numWorkers++ {
 				if bytes, err := io.ReadAll(GetDownloadStream(downloader, chunkSize, numWorkers)); err == nil {
 					actual := string(bytes)
 					if actual != data {
@@ -119,12 +119,12 @@ func TestRangeReader(t *testing.T) {
 }
 
 func TestMultipartRangeReader(t *testing.T) {
-	opts.RetryCount = 3
-	for fileSize := int64(0); fileSize < 8; fileSize++ {
+	opts.RetryCount = math.MaxInt64
+	for fileSize := int64(0); fileSize < 64; fileSize++ {
 		data := RandomString(fileSize)
 		downloader := TestDownloader{data, true, true}
-		for chunkSize := int64(1); chunkSize < 4; chunkSize++ {
-			for numWorkers := 1; numWorkers < 4; numWorkers++ {
+		for chunkSize := int64(1); chunkSize < 32; chunkSize++ {
+			for numWorkers := 1; numWorkers < 32; numWorkers++ {
 				if bytes, err := io.ReadAll(GetDownloadStream(downloader, chunkSize, numWorkers)); err == nil {
 					actual := string(bytes)
 					if actual != data {

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"math/rand"
 	"mime/multipart"
 	"net/http"

--- a/fastar.go
+++ b/fastar.go
@@ -112,8 +112,6 @@ func main() {
 		}
 		ExtractTar(finalStream)
 	}
-
-	log.Println("Done")
 }
 
 // Reads first few bytes from file stream to get any possible

--- a/fastar.go
+++ b/fastar.go
@@ -35,7 +35,7 @@ var opts struct {
 	Headers         map[string]string `long:"headers" short:"H" description:"Headers to use with http request"`
 	UseFips         bool              `long:"use-fips-endpoint" description:"Use FIPS endpoint when downloading from S3"`
 	DisableHttp2    bool              `long:"disable-http2" description:"Disable http2 to avoid reusing connections for GCS downloads"`
-	UseGetForSize   bool              `long:"use-get-for-size" description:"Use GET with Range header instead of HEAD to determine file size for HTTP(S) URLs"`
+	UseGetForSize   bool              `long:"use-get-for-size" description:"Use GET with Range header instead of HEAD to determine file size for HTTP(S) URLs. Assumes RANGE support on the server side."`
 }
 
 var minSpeedBytesPerMillisecond = 0.0

--- a/fastar.go
+++ b/fastar.go
@@ -35,6 +35,7 @@ var opts struct {
 	Headers         map[string]string `long:"headers" short:"H" description:"Headers to use with http request"`
 	UseFips         bool              `long:"use-fips-endpoint" description:"Use FIPS endpoint when downloading from S3"`
 	DisableHttp2    bool              `long:"disable-http2" description:"Disable http2 to avoid reusing connections for GCS downloads"`
+	UseGetForSize   bool              `long:"use-get-for-size" description:"Use GET with Range header instead of HEAD to determine file size for HTTP(S) URLs"`
 }
 
 var minSpeedBytesPerMillisecond = 0.0
@@ -68,7 +69,7 @@ func main() {
 	var rawUrl = args[0]
 	processMinSpeedFlag()
 	opts.ChunkSize *= 1e6 // Convert chunk size from MB to B
-	fileStream := GetDownloadStream(GetDownloader(rawUrl, opts.UseFips), opts.ChunkSize, opts.NumWorkers)
+	fileStream := GetDownloadStream(GetDownloader(rawUrl, opts.UseFips, opts.UseGetForSize), opts.ChunkSize, opts.NumWorkers)
 
 	url, err := url.Parse(rawUrl)
 	if err != nil {
@@ -111,6 +112,8 @@ func main() {
 		}
 		ExtractTar(finalStream)
 	}
+
+	log.Println("Done")
 }
 
 // Reads first few bytes from file stream to get any possible

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -27,6 +27,10 @@ func (httpDownloader HttpDownloader) GetFileInfo() (int64, bool, bool) {
 	var resp *http.Response
 	var contentLength int64
 
+	// If useGetForSize is true, use GET with Range header to determine file size.
+	// This was inspired by https://stackoverflow.com/questions/15717230/pre-signing-amazon-s3-urls-for-both-head-and-get-verbs,
+	// which in turn allows usage of S3 presigned URLs which can only be signed for one HTTP method.
+	// This has been tested on AWS, Azure, and GCP.
 	if httpDownloader.useGetForSize {
 		// Use GET with Range header to determine file size
 		req := httpDownloader.generateRequest("GET")

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -48,12 +48,10 @@ func (httpDownloader HttpDownloader) GetFileInfo() (int64, bool, bool) {
 				if size, err := strconv.ParseInt(parts[1], 10, 64); err == nil {
 					contentLength = size
 				} else {
-					log.Printf("Failed to parse Content-Range size: %s", err.Error())
-					contentLength = resp.ContentLength
+					log.Fatal("Failed to parse Content-Range size: ", err.Error())
 				}
 			} else {
-				log.Printf("Unexpected Content-Range format: %s", contentRange)
-				contentLength = resp.ContentLength
+				log.Fatal("Unexpected Content-Range format: ", contentRange)
 			}
 		} else {
 			log.Fatal("Content-Range missing on response when using GET for size. Failing download.")

--- a/http_downloader.go
+++ b/http_downloader.go
@@ -49,6 +49,7 @@ func (httpDownloader HttpDownloader) GetFileInfo() (int64, bool, bool) {
 				contentLength = resp.ContentLength
 			}
 		} else {
+			log.Printf("Falling back to Content-Length due to missing Content-Range: %d", resp.ContentLength)
 			contentLength = resp.ContentLength
 		}
 		


### PR DESCRIPTION
Currently, fastar supports HTTPS urls.

BUT, there's a caveat. S3-presigned URLs are only valid for 1 HTTP verb. Fastar uses HEADs to get the content size of the blob to be downloaded, and GETs with range values to fetch pieces.

To work around this, I added support for fetching the content length by a dummy GET request which requests bytes 0-0. This was inspired by https://stackoverflow.com/questions/15717230/pre-signing-amazon-s3-urls-for-both-head-and-get-verbs (answer at https://stackoverflow.com/a/39663152).

Tested by fetching a bunch of blobs that are tars (specifically, blobs served by an OCI-compatible registry with S3 under the hood).

The option to invoke this flow is gated by a command line flag `--use-get-for-size`. Open to suggestions on naming.


Tested on GCP:

```
# v.patel at ip-10-90-18-172 in ~/fastar (git:http_support_get_only_urls) [18:13:13]
$ ./fastar --use-get-for-size --directory testgcp https://storage.googleapis.com/dbharbordpdev-us-east4/docker/registry/v2/blobs/sha256/ea/ea8e43d2c1543a152cdb4fe725e71bab3c7ef2bf7c71eed5dbbf5af726065199/data\?Expires\=1756837978\&GoogleAccessId\=harbor-dataplane-sa%40databricks-dev-us-east4.iam.gserviceaccount.com\&Signature\=ev33awKh8pNLvs7WCSG6Xz9ASaflgMOYUjj9gxccDS7bTxdjMdqwJ19lcvU06IyeZbCJh78ofqczvlESANSmuZEr5Yl3pth2kpc44bMg7RrD%2FXmUd66wOEY52Qse3XNAYKXAflDKne%2Bpu%2Fm07rZIXfNSctJ%2F4lLe4NADPbY0UmstLX1gto6nLj%2BmQJedPfg%2BsRHC5SfoLEDIitDt1t7Q4P%2BBSNpmL9sHFTI8QgSrYKS3Qh%2FDrZZnqZ9lPJqDg0rHK1LB0dC825hIuEfIc2Y1aIa9%2FT8%2FN9EJ84UWM1AOB7vR8IekVz1%2Fm5SzLpynf8rol0aPxE6%2FwqTLTzSHy8vmEQ%3D%3D
2025/09/02 18:13:29 File Size (B): 1542515200
2025/09/02 18:13:29 File Size (MiB): 1542
2025/09/02 18:13:29 Supports RANGE: true
2025/09/02 18:13:29 Supports multipart RANGE: false
2025/09/02 18:13:29 File name: data
2025/09/02 18:13:29 Num Download Workers: 4
2025/09/02 18:13:29 Chunk Size (Mib): 200
2025/09/02 18:13:29 Num Disk Workers: 8
2025/09/02 18:13:29 Unrecognized magic number, falling back to file extension
2025/09/02 18:13:29 Unrecognized file extension, assuming raw tar
2025/09/02 18:13:38 Worker 0 final download speed 44.430MBps
2025/09/02 18:13:39 Worker 1 final download speed 43.563MBps
2025/09/02 18:13:39 Worker 2 final download speed 43.516MBps
2025/09/02 18:13:39 Worker 3 final download speed 41.010MBps
# v.patel at ip-10-90-18-172 in ~/fastar (git:http_support_get_only_urls) [18:13:39]
$ ls testgcp/databricks
jars  log-daemon
# v.patel at ip-10-90-18-172 in ~/fastar (git:http_support_get_only_urls) [18:13:45]
$ ls testgcp/databricks/log-daemon
0006a8b737f3d838db6c92f7fc8e7cf45c15dbd9c44b597c8de8430d59f9de12-cluster_events_proto-jetty9-hadoop1_2.12-scalabp.jar
000f9bda30f9a5fd41cf1f8bce2f11c55f74a66e4ba1634d9f53cf9607b4fb9d-feature_store_get_feature_tables_by_id_api_called_proto-jetty9-hadoop1_2.12-scalabp.jar
001514aef0ff3a4f4820ff3166ec517c3ca6f25208613b28d519f849b3950794-com.microsoft.azure__azure-mgmt-compute__1.41.4.jar
002320a92061b94132e6abbbf32284bd3a1c61fadd0143d689bc7c83c732e404-common_proto-jetty9-hadoop1_2.12-scalabp.jar
002dd1166d6de07ad0bacca73bb5e953991da84d375e20c0e1585e2053494e25-log-common-jetty9-hadoop1_2.12_deploy.jar
003325ac5d811a8a52b83e838d1a20e20182cae3b0bf3b0d87d6436d0c2a9a36-public-jetty9-hadoop1_2.12_deploy.jar
003b6e5e43b68b1e0513dfc7c99c8938e76397c7671dd91341caac550193c82c-manifest-info-jetty9-hadoop1_2.12_deploy.jar
0056d08e31ee1a3c0f4aeb913a1b76054c0e4eba60b3ac73aaa3fd5696d67f20-observability-jetty9-hadoop1_2.12_deploy.jar
0056fddaeb21f3cdc896700d8ab4e554326fe2e3e4fa105f4d1805744d2594c7-dns-jetty9-hadoop1_2.12_deploy.jar
00753977e78be00a5414c571919b8a447caa8353cef4db33067f50fc2608a96d-vector_log_wrapper-jetty9-hadoop1_2.12_deploy.jar
00805988788c952e94a3fb4a471f763202322e0d6c60d8d72d47d512dc83bf54-from_json_event_proto-jetty9-hadoop1_2.12-scalabp.jar
008929f86eafff74190cf5efc59e396f25ec08dcf3fa5c2202e7ac0a3128f7f1-io.netty__netty-tcnative-boringssl-static__2.0.70.Final-db-r0-osx-x86_64.jar
00a3101680ff4fd12e08ec58121382fad150274785ace96105f01e2f79730089-guid-jetty9-hadoop1_2.12_deploy.jar
00df2466b61b0f98e1f1be7f243fc11070f129e47f7262b4a47e94e3d292f37c-denylister-jetty9-hadoop1_2.12_deploy.jar
```


And Azure as well:
```
 v.patel at ip-10-90-18-172 in ~/fastar (git:http_support_get_only_urls) [18:15:39]
$ ./fastar --use-get-for-size --directory testazure https://dbartifactsdevwestus.blob.core.windows.net/harbor/docker/registry/v2/blobs/sha256/0d/0dbc2a4cd12b77102aa62d81de1119d541c17cd37efcdbf5ec531de36c92c675/data\?se\=2025-09-02T18%3A20%3A37Z\&sig\=LCSbgxRQ0Lp9InwoLivg5%2Fltx3sjlgQPPuBVpq2AjnU%3D\&sp\=r\&spr\=https\&sr\=b\&st\=2025-09-02T17%3A20%3A27Z\&sv\=2025-05-05
2025/09/02 18:15:45 File Size (B): 1685381120
2025/09/02 18:15:45 File Size (MiB): 1685
2025/09/02 18:15:45 Supports RANGE: true
2025/09/02 18:15:45 Supports multipart RANGE: false
2025/09/02 18:15:45 File name: data
2025/09/02 18:15:45 Num Download Workers: 4
2025/09/02 18:15:45 Chunk Size (Mib): 200
2025/09/02 18:15:45 Num Disk Workers: 8
2025/09/02 18:15:45 Unrecognized magic number, falling back to file extension
2025/09/02 18:15:45 Unrecognized file extension, assuming raw tar
2025/09/02 18:15:54 Worker 1 final download speed 57.053MBps
2025/09/02 18:15:54 Worker 2 final download speed 55.625MBps
2025/09/02 18:15:55 Worker 3 final download speed 51.322MBps
2025/09/02 18:15:56 Worker 0 final download speed 49.514MBps
# v.patel at ip-10-90-18-172 in ~/fastar (git:http_support_get_only_urls) [18:15:56]
$ ls testazure/databricks
data-daemon  jars  log-daemon  node-daemon  security-daemon
# v.patel at ip-10-90-18-172 in ~/fastar (git:http_support_get_only_urls) [18:16:00]
$ ls testazure/databricks/log-daemon
001514aef0ff3a4f4820ff3166ec517c3ca6f25208613b28d519f849b3950794-com.microsoft.azure__azure-mgmt-compute__1.41.4.jar
002489f856b2e309514c059b29604ac831677f7ee804bacfc148588f948f3f16-sjsonnet-utils-jetty9-hadoop1_2.12_deploy.jar
003b6e5e43b68b1e0513dfc7c99c8938e76397c7671dd91341caac550193c82c-manifest-info-jetty9-hadoop1_2.12_deploy.jar
00469fd099ecdd4c2b9f53289f8b8c83d6ceea6657b4009137aab19e7024e461-snapstart_scala_lib-jetty9-hadoop1_2.12_deploy.jar
0056d08e31ee1a3c0f4aeb913a1b76054c0e4eba60b3ac73aaa3fd5696d67f20-observability-jetty9-hadoop1_2.12_deploy.jar
0056fddaeb21f3cdc896700d8ab4e554326fe2e3e4fa105f4d1805744d2594c7-dns-jetty9-hadoop1_2.12_deploy.jar
00753977e78be00a5414c571919b8a447caa8353cef4db33067f50fc2608a96d-vector_log_
```