### PR TITLE
[CJ-68923] allow skipping head call to download URL

### DIFF
--- a/fastar.go
+++ b/fastar.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"log"
 	"net/url"
@@ -15,6 +16,8 @@ import (
 	"github.com/jessevdk/go-flags"
 	"github.com/pierrec/lz4"
 )
+
+const version = "2.9.0"
 
 var opts struct {
 	NumWorkers      int               `long:"download-workers" default:"4" description:"How many parallel workers to download the file"`
@@ -35,6 +38,10 @@ var opts struct {
 	Headers         map[string]string `long:"headers" short:"H" description:"Headers to use with http request"`
 	UseFips         bool              `long:"use-fips-endpoint" description:"Use FIPS endpoint when downloading from S3"`
 	DisableHttp2    bool              `long:"disable-http2" description:"Disable http2 to avoid reusing connections for GCS downloads"`
+	SkipHead        bool              `long:"skip-head" description:"Skip HEAD request for HTTP downloads (useful for presigned URLs)"`
+	ContentLength   int64             `long:"content-length" description:"Content length to use when skipping HEAD request"`
+	AcceptRanges    string            `long:"accept-ranges" description:"Accept-Ranges header value to use when skipping HEAD request"`
+	Version         bool              `long:"version" description:"Show version information"`
 }
 
 var minSpeedBytesPerMillisecond = 0.0
@@ -62,6 +69,12 @@ func main() {
 	if err != nil {
 		log.Fatal("Failed to parse arguments: ", err)
 	}
+
+	if opts.Version {
+		fmt.Printf("fastar version %s\n", version)
+		os.Exit(0)
+	}
+
 	if len(args) == 0 {
 		log.Fatal("Please pass source URL to download file from")
 	}


### PR DESCRIPTION
## What changes are proposed in this pull request?

  This PR adds functionality to skip HEAD requests for HTTP downloads, which is particularly useful for presigned URLs that may not support HEAD requests or have different authentication requirements for HEAD vs GET operations.

  **Key changes:**
  - Added `--skip-head` flag to bypass HEAD requests
  - Added `--content-length` flag to specify file size when skipping HEAD
  - Added `--accept-ranges` flag to specify range support when skipping HEAD
  - Added `--version` flag to display version information (v2.9.0)
  - Modified `GetFileInfo()` method to use provided values when skipping HEAD requests
  - Maintained existing logic for determining multipart support based on file size vs chunk size

  ## How is this tested?

  - Added comprehensive unit tests covering all scenarios:
    - Small file HEAD request behavior
    - Large file HEAD request behavior
    - Large file skip-head behavior
    - Small file skip-head behavior
    - Empty accept-ranges header handling
  - Tests verify correct content length, accept ranges, and multipart support detection
  - Existing functionality remains unchanged when skip-head is disabled

  ## How is this feature monitored?

  No additional monitoring required - this is a client-side configuration option that doesn't affect server-side behavior or require new metrics.

  ## Performance implications

  - **Positive**: Reduces latency by eliminating HEAD request for scenarios where it's not needed
  - **Neutral**: No performance impact when feature is not used (default behavior unchanged)
  - File size detection logic remains the same for determining multipart download strategy